### PR TITLE
Version limits

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,7 @@
+=== Version 2.0.2 / 2016-11-19
+
+* The gem now declares version limits for all of its dependencies.
+
 === Version 2.0.1 / 2016-11-08
 
 * Works with both 0.x and 1.x versions of the 'cuke_modeler' gem.

--- a/cuke_slicer.gemspec
+++ b/cuke_slicer.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cuke_modeler", "< 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake" , '~> 11.0'
   spec.add_development_dependency "rspec", '~> 3.0'
-  spec.add_development_dependency "cucumber"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "racatt"
+  spec.add_development_dependency "cucumber", '~> 2.0'
+  spec.add_development_dependency "simplecov", '~> 0.0'
+  spec.add_development_dependency "racatt", '~> 1.0'
   spec.add_development_dependency 'coveralls', '< 1.0.0'
 
 end

--- a/lib/cuke_slicer/version.rb
+++ b/lib/cuke_slicer/version.rb
@@ -1,4 +1,4 @@
 module CukeSlicer
   # The current version for the gem.
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
Went ahead and added version limits on the gem dependencies so that the gem builds without warnings and we don't have another situation where a major version release breaks things.