### PR TITLE
Update for CukeModeler 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
 gemfile:
   - gemfiles/cuke_modeler0.gemfile
   - gemfiles/cuke_modeler1.gemfile
+  - gemfiles/cuke_modeler2.gemfile
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     # Travis does not provide 1.9.3 on OSX
     - rvm: 1.9.3
       os: osx
+    # Ruby 2.3.x for OSX is currently broken on TravisCI and is no longer a supported Ruby version, anyway.
+    - rvm: 2.3.8
+      os: osx
 
 
 script: bundle exec rake cuke_slicer:ci_build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Nothing yet...
+
+
+## [2.0.3] - 2019-05-01
+
 ### Added
 
  - Add dependency version limits to Ruby, which was previously unbound. Previously unofficially supported Ruby versions (1.9.3 - 2.x) are now officially supported.
@@ -43,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Initial release
 
-[Unreleased]: https://github.com/grange-insurance/cuke_slicer/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/grange-insurance/cuke_slicer/compare/v2.0.3...HEAD
+[2.0.3]: https://github.com/grange-insurance/cuke_slicer/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/grange-insurance/cuke_slicer/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/grange-insurance/cuke_slicer/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/grange-insurance/cuke_slicer/compare/v1.0.0...v2.0.0

--- a/cuke_slicer.gemspec
+++ b/cuke_slicer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3', '< 3.0'
 
-  spec.add_runtime_dependency "cuke_modeler", "< 2.0"
+  spec.add_runtime_dependency "cuke_modeler", "< 3.0"
 
   spec.add_development_dependency 'bundler', '< 3.0'
   spec.add_development_dependency 'rake', '< 13.0.0'

--- a/gemfiles/cuke_modeler2.gemfile
+++ b/gemfiles/cuke_modeler2.gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+gemspec :path => "../"
+
+gem 'cuke_modeler', '~> 2.0'
+
+
+if RUBY_VERSION =~ /^1\./
+  gem 'cucumber', '< 3.0.0' # Ruby 1.9.x support dropped after this version
+  gem 'json', '< 2.0' # The 'json' gem drops pre-Ruby 2.x support on/after this version
+  gem 'tins', '< 1.7' # The 'tins' gem requires Ruby 2.x on/after this version
+  gem 'term-ansicolor', '< 1.4' # The 'term-ansicolor' gem requires Ruby 2.x on/after this version
+end

--- a/lib/cuke_slicer/collections/nested_tag_collection.rb
+++ b/lib/cuke_slicer/collections/nested_tag_collection.rb
@@ -1,6 +1,8 @@
 require "cuke_slicer/helpers/helpers"
 
 
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class NestedTagCollection
 

--- a/lib/cuke_slicer/collections/path_collection.rb
+++ b/lib/cuke_slicer/collections/path_collection.rb
@@ -1,6 +1,8 @@
 require "cuke_slicer/helpers/helpers"
 
 
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class PathCollection
 

--- a/lib/cuke_slicer/collections/tag_collection.rb
+++ b/lib/cuke_slicer/collections/tag_collection.rb
@@ -2,6 +2,8 @@ require "cuke_slicer/helpers/helpers"
 require "cuke_slicer/collections/nested_tag_collection"
 
 
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class TagCollection
 

--- a/lib/cuke_slicer/extractors/directory_extractor.rb
+++ b/lib/cuke_slicer/extractors/directory_extractor.rb
@@ -1,3 +1,5 @@
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class DirectoryExtractor
 

--- a/lib/cuke_slicer/extractors/file_extractor.rb
+++ b/lib/cuke_slicer/extractors/file_extractor.rb
@@ -3,6 +3,8 @@ require "cuke_slicer/helpers/filter_helpers"
 require "cuke_slicer/helpers/extraction_helpers"
 
 
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class FileExtractor
 

--- a/lib/cuke_slicer/filters/filter_set.rb
+++ b/lib/cuke_slicer/filters/filter_set.rb
@@ -3,6 +3,8 @@ require "cuke_slicer/collections/tag_collection"
 require "cuke_slicer/collections/path_collection"
 
 
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   class FilterSet
 

--- a/lib/cuke_slicer/helpers/extraction_helpers.rb
+++ b/lib/cuke_slicer/helpers/extraction_helpers.rb
@@ -1,3 +1,5 @@
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   module ExtractionHelpers
 

--- a/lib/cuke_slicer/helpers/filter_helpers.rb
+++ b/lib/cuke_slicer/helpers/filter_helpers.rb
@@ -1,3 +1,5 @@
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   module FilterHelpers
 

--- a/lib/cuke_slicer/helpers/helpers.rb
+++ b/lib/cuke_slicer/helpers/helpers.rb
@@ -1,3 +1,5 @@
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   module Helpers
 

--- a/lib/cuke_slicer/helpers/matching_helpers.rb
+++ b/lib/cuke_slicer/helpers/matching_helpers.rb
@@ -29,7 +29,7 @@ module CukeSlicer
 
     def filter_match(element, filter)
       tag_values = element.all_tags
-      tag_values = tag_values.collect { |tag| tag.name } if Gem.loaded_specs['cuke_modeler'].version.version[/^1/]
+      tag_values = tag_values.collect { |tag| tag.name } if Gem.loaded_specs['cuke_modeler'].version.version[/^[12]/]
 
       if filter.is_a?(Regexp)
         tag_values.any? { |tag| tag =~ filter }

--- a/lib/cuke_slicer/helpers/matching_helpers.rb
+++ b/lib/cuke_slicer/helpers/matching_helpers.rb
@@ -1,3 +1,5 @@
+# Internal helper module that is not part of the public API. Subject to change at any time.
+# :nodoc: all
 module CukeSlicer
   module MatchingHelpers
 

--- a/lib/cuke_slicer/version.rb
+++ b/lib/cuke_slicer/version.rb
@@ -1,4 +1,4 @@
 module CukeSlicer
   # The current version for the gem.
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end


### PR DESCRIPTION
This PR updates `cuke_slicer` so that it is compatible with the current major version of `cuke_modeler`.